### PR TITLE
refactor: migrate to using asyncio.create_task

### DIFF
--- a/src/aioharmony/__main__.py
+++ b/src/aioharmony/__main__.py
@@ -586,7 +586,7 @@ async def run():
         hub_ips = args.harmony_ip.split(",")
         for hub in hub_ips:
             # Connect to the HUB
-            hub_tasks.append(asyncio.ensure_future(execute_per_hub(hub, args)))
+            hub_tasks.append(asyncio.create_task(execute_per_hub(hub, args)))
 
         results = await asyncio.gather(*hub_tasks, return_exceptions=True)
         for result in results:

--- a/src/aioharmony/helpers.py
+++ b/src/aioharmony/helpers.py
@@ -112,7 +112,7 @@ def call_raw_callback(
             return wrapped
 
         partial_func = async_partial(callback, result)
-        task = asyncio.ensure_future(partial_func())
+        task = asyncio.create_task(partial_func())
         _CALLBACK_TASKS.add(task)
         task.add_done_callback(_CALLBACK_TASKS.discard)
         return True

--- a/src/aioharmony/hubconnector_websocket.py
+++ b/src/aioharmony/hubconnector_websocket.py
@@ -192,7 +192,7 @@ class HubConnector:
 
             # Now put the listener on the loop.
             if not self._listener_task:
-                self._listener_task = asyncio.ensure_future(
+                self._listener_task = asyncio.create_task(
                     self._listener(self._websocket)
                 )
 
@@ -301,7 +301,7 @@ class HubConnector:
                 "Accept-Charset": "utf-8",
             }
             json_request = {"id ": msgid, "cmd": command, "params": {}}
-            response = asyncio.ensure_future(self.hub_post(url, json_request, headers))
+            response = asyncio.create_task(self.hub_post(url, json_request, headers))
             return response
 
         # Make sure we're connected.

--- a/src/aioharmony/responsehandler.py
+++ b/src/aioharmony/responsehandler.py
@@ -57,7 +57,7 @@ class ResponseHandler:
         self._name = name
         self._handler_list = []
 
-        self._callback_task = asyncio.ensure_future(self._callback_handler())
+        self._callback_task = asyncio.create_task(self._callback_handler())
 
     async def close(self):
         """


### PR DESCRIPTION
asyncio.create_task is prefered over asyncio.ensure_future for scheduling coros in newer Python