### PR TITLE
fix: call get_running_loop instead of get_event_loop

### DIFF
--- a/src/aioharmony/harmonyapi.py
+++ b/src/aioharmony/harmonyapi.py
@@ -45,7 +45,7 @@ class HarmonyAPI:
         loop: asyncio.AbstractEventLoop = None,
     ) -> None:
         _LOGGER.debug("%s: Initialize", ip_address)
-        loop = loop if loop else asyncio.get_event_loop()
+        loop = loop if loop else asyncio.get_running_loop()
         self._harmony_client = HarmonyClient(
             ip_address=ip_address, protocol=protocol, callbacks=callbacks, loop=loop
         )

--- a/src/aioharmony/harmonyclient.py
+++ b/src/aioharmony/harmonyclient.py
@@ -61,7 +61,7 @@ class HarmonyClient:
             if callbacks is not None
             else ClientCallbackType(None, None, None, None, None)
         )
-        self._loop = loop if loop else asyncio.get_event_loop()
+        self._loop = loop if loop else asyncio.get_running_loop()
 
         self._hub_config = ClientConfigType({}, {}, {}, {}, None, [], [])
         self._current_activity_id = None

--- a/src/aioharmony/hubconnector_xmpp.py
+++ b/src/aioharmony/hubconnector_xmpp.py
@@ -149,7 +149,7 @@ class HubConnector(slixmpp.ClientXMPP):
             else:
                 log_level = 40
 
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             connected = loop.create_future()
 
             def connection_success(_):
@@ -252,7 +252,7 @@ class HubConnector(slixmpp.ClientXMPP):
             # reconnect.
             self._connected = False
 
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             disconnected = loop.create_future()
 
             def disconnect_result(_):


### PR DESCRIPTION
Calling get_event_loop when there is no running loop is deprecated in Python 3.12+

https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop

> Because this function has rather complex behavior (especially when custom event loop policies are in use), using the get_running_loop() function is preferred to get_event_loop() in coroutines and callbacks.